### PR TITLE
Update 257 - scott goes linux.md

### DIFF
--- a/shows/257 - scott goes linux.md
+++ b/shows/257 - scott goes linux.md
@@ -28,7 +28,7 @@ LogRocket lets you replay what users do on your site, helping you reproduce bugs
 
 10:07 - I can still run:
 
-* [Alfred](https://www.alfredapp.com/)
+* [Albert (alfred)](https://github.com/albertlauncher/albert)
 * [Figma](https://www.figma.com/)
 * [VSCode](https://code.visualstudio.com/)
 * [DaVinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve/)


### PR DESCRIPTION
The link I changed pointed to alfred for mac. The app Scott uses is albert, though.